### PR TITLE
use a pronto-specific lcmtype to avoid drake dependency

### DIFF
--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
@@ -66,7 +66,7 @@ LegOdoHandler::LegOdoHandler(lcm::LCM* lcm_recv,  lcm::LCM* lcm_pub,
     lcm_recv->subscribe("WEBCAM",&LegOdoHandler::republishHandler,this);  
   }
  
-  lcm_recv->subscribe("QP_CONTROLLER_INPUT",&LegOdoHandler::controllerInputHandler,this);
+  lcm_recv->subscribe("CONTROLLER_FOOT_CONTACT",&LegOdoHandler::controllerInputHandler,this);
   n_control_contacts_left_ = -1;
   n_control_contacts_right_ = -1;
 
@@ -200,20 +200,9 @@ void LegOdoHandler::poseBodyHandler(const lcm::ReceiveBuffer* rbuf, const std::s
 }
 
 
-void LegOdoHandler::controllerInputHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  drake::lcmt_qp_controller_input* msg){
-  n_control_contacts_left_ = 0;
-  n_control_contacts_right_ = 0;
-  for (int i=0; i < msg->num_support_data; i++){
-
-    if (msg->support_data[i].body_id == 12)
-      n_control_contacts_left_ = msg->support_data[i].num_contact_pts;
-
-    if (msg->support_data[i].body_id == 25)
-      n_control_contacts_right_ = msg->support_data[i].num_contact_pts;
-  }
-
-  // std::cout << "got drake: " << n_control_contacts_left_ << " " << n_control_contacts_right_ << "\n";
-
+void LegOdoHandler::controllerInputHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  pronto::controller_foot_contact_t* msg){
+  n_control_contacts_left_ = msg->num_right_foot_contacts;
+  n_control_contacts_right_ = msg->num_left_foot_contacts;
 }
 
 RBISUpdateInterface * LegOdoHandler::processMessage(const pronto::atlas_state_t *msg){

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -19,7 +19,7 @@
 #include <estimate_tools/torque_adjustment.hpp>
 
 #include <lcmtypes/pronto/atlas_state_t.hpp>
-#include "lcmtypes/drake/lcmt_qp_controller_input.hpp"
+#include <lcmtypes/pronto/controller_foot_contact_t.hpp>
 
 namespace MavStateEst {
   
@@ -52,7 +52,7 @@ public:
   void poseBodyHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::pose_t* msg);  
   void viconHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::rigid_transform_t* msg);  
   void republishHandler (const lcm::ReceiveBuffer* rbuf, const std::string& channel);
-  void controllerInputHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  drake::lcmt_qp_controller_input* msg);
+  void controllerInputHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  pronto::controller_foot_contact_t* msg);
 
   void sendTransAsVelocityPose(BotTrans msgT, int64_t utime, int64_t prev_utime, std::string channel);
   

--- a/pronto-lcmtypes/lcmtypes/pronto_controller_foot_contact_t.lcm
+++ b/pronto-lcmtypes/lcmtypes/pronto_controller_foot_contact_t.lcm
@@ -1,0 +1,13 @@
+package pronto;
+
+struct controller_foot_contact_t
+{
+	int64_t utime;
+
+	int32_t num_right_foot_contacts;
+	double right_foot_contacts[3][num_right_foot_contacts];
+
+	int32_t num_left_foot_contacts;
+	double left_foot_contacts[3][num_left_foot_contacts];
+
+}


### PR DESCRIPTION
relies on the message published by drc-controller-contact-passthrough, introduced in https://github.com/mitdrc/drc/compare/master...drcbot:mfallon-listen-to-the-control-people-say