### PR TITLE
Experimental: allow constant offsets in torque deflection correction

### DIFF
--- a/estimate_tools/src/backlash_filter_tools/torque_adjustment.cpp
+++ b/estimate_tools/src/backlash_filter_tools/torque_adjustment.cpp
@@ -3,10 +3,11 @@
 
 #include <estimate_tools/torque_adjustment.hpp>
 #include <cmath>
+#include <stdexcept>
 
 namespace EstimateTools {
 
-TorqueAdjustment::TorqueAdjustment(std::vector<float> k_):k_(k_){
+TorqueAdjustment::TorqueAdjustment(std::vector<float> k_):k_(k_) {
   // Construct a torque adjustment tool with the given spring constants. The
   // vector k_ should be the same length as the number of efforts and
   // positions (and in the same order), and is measured in units of radians
@@ -18,6 +19,41 @@ TorqueAdjustment::TorqueAdjustment(std::vector<float> k_):k_(k_){
   for( size_t i=0; i<k_.size(); i++)
     std::cout << k_[i] << ' ';
   std::cout << "\n";
+
+  max_adjustment_ = 0.1; // 0.1 was always used
+
+  offset.resize(k_.size());
+  for (size_t i=0; i<k_.size(); i++) {
+    offset[i] = 0;
+  }
+}
+
+TorqueAdjustment::TorqueAdjustment(std::vector<float> k_, std::vector<float> offset): k_(k_), offset(offset) {
+  // Construct a torque adjustment tool with the given spring constants. The
+  // vector k_ should be the same length as the number of efforts and
+  // positions (and in the same order), and is measured in units of radians
+  // per Newton-meter. To prevent torque adjustment on a joint, set its
+  // associated value of k_ to inf (since a joint with no deflection can be
+  // thought of as an infinitely stiff spring).
+  //
+  // In addition, this constructor supports a vector of constant offsets to
+  // apply to each joint. Note that these are separate from our encoder
+  // offsets and are meant only to handle offsets in the leg joints used for
+  // leg odometry, etc.
+  std::cout << "TorqueAdjustment gains: ";
+
+  for( size_t i=0; i<k_.size(); i++)
+    std::cout << k_[i] << ' ';
+  std::cout << "\n";
+
+  std::cout << "Offsets: ";
+  for( size_t i=0; i<offset.size(); i++)
+    std::cout << offset[i] << ' ';
+  std::cout << "\n";
+
+  if (offset.size() != k_.size()) {
+    throw std::runtime_error("offset and k_ should be the same size");
+  }
 
   max_adjustment_ = 0.1; // 0.1 was always used
 }
@@ -37,6 +73,7 @@ void TorqueAdjustment::processSample(std::vector<float> &position, std::vector<f
     if (std::isnormal(k_[i])) {
       // Don't do the correction if k_[i] is zero, NaN, or infinite. 
       position[i] -= magnitudeLimit( effort[i] / k_[i]);
+      position[i] += offset[i];
     }
   }
 

--- a/estimate_tools/src/backlash_filter_tools/torque_adjustment.hpp
+++ b/estimate_tools/src/backlash_filter_tools/torque_adjustment.hpp
@@ -12,6 +12,7 @@ namespace EstimateTools {
 class TorqueAdjustment{
   public:
     TorqueAdjustment(std::vector<float> k_);
+    TorqueAdjustment(std::vector<float> k_, std::vector<float> offset);
 
     ~TorqueAdjustment(){
     }
@@ -24,6 +25,7 @@ class TorqueAdjustment{
     float max_adjustment_;
 
     std::vector<float> k_;
+    std::vector<float> offset;
 
 };
 

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
@@ -34,8 +34,17 @@ LegOdoHandler::LegOdoHandler(lcm::LCM* lcm_recv,  lcm::LCM* lcm_pub,
     for (int i =0; i < n_gains;i++){
       k.push_back( (float) gains_in[i] );
     }
-    torque_adjustment_ = new EstimateTools::TorqueAdjustment(k);
-
+    int n_offsets = bot_param_get_array_len(param, "state_estimator.legodo.adjustment_offset");
+    if (n_offsets != n_gains) {
+      throw std::runtime_error("number of torque adjustment offsets must match number of deflection gains");
+    }
+    double offsets_in[n_offsets];
+    bot_param_get_double_array_or_fail(param, "state_estimator.legodo.adjustment_offset", &offsets_in[0], n_offsets);
+    std::vector<float> offset;
+    for (int i=0; i < n_offsets; i++) {
+      offset.push_back( (float) offsets_in[i] );
+    }
+    torque_adjustment_ = new EstimateTools::TorqueAdjustment(k, offset);
   }else{
     std::cout << "Torque-based joint angle adjustment: Not Using\n";
   }


### PR DESCRIPTION
@tkoolen has some evidence to suggest that there's a substantial constant offset in some of our leg joints. He's not sure yet, but I'd like to get the machinery in place to use those numbers if they're significant. 

This extends the torqueAdjustment class to support a constant offset for each joint. By default it's set to 0 for all joints, and this preserves the existing one-argument constructor. 

@mauricefallon and @kuindersma could you please look at this?

We certainly won't merge this until it's proven on the robot, but I want to make sure all the pieces are ready in case we decide to use the offsets. 